### PR TITLE
[autopilot] release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-08-08
+
+First release since `0.0.5`. The library has been modernized for current Python
+and pandas, and its entire numerical core has been rewritten from scratch as a C
+extension — `scipy` and `statsmodels` are no longer dependencies.
+
+The `detect_ts` signature, parameters, and results are unchanged, and its outputs
+are pinned to the previous implementation by golden tests. **The import name and
+the license both changed**, so read the migration notes below before upgrading.
+
+### Migrating from 0.0.5
+
+- **Import from `pyculiar`, not `pyculiarity`:**
+
+  ```python
+  # before
+  from pyculiarity import detect_ts
+
+  # after
+  from pyculiar import detect_ts
+  ```
+
+  The PyPI distribution name is unchanged (`pip install pyculiar`); only the
+  module you import from moved, so that it matches the package name.
+
+- **The license changed from GPL-3.0 to MIT.** If your usage depended on the
+  copyleft terms, review the new [LICENSE](LICENSE).
+
+- **Python 3.10+ and pandas 2.0+ are now required.** Stay on `0.0.5` if you need
+  Python 2 or pandas 1.x.
+
+### Removed
+
+- **`scipy`, `statsmodels`, `patsy`, `pytz`, and `future` are no longer
+  dependencies.** Runtime requirements are now just `numpy` and `pandas>=2.0`.
+- The `pyculiarity.stl` module (`stl()`, a statsmodels-backed LOESS
+  decomposition) is gone. Seasonal decomposition now happens inside the C
+  extension; call `pyculiar._cext.anomaly_module.seasonal_decompose(values, period)`
+  if you were using it directly.
+- Python 2 compatibility shims (`future`, `past.builtins`).
+
+### Changed
+
+- **The computational core is now a C extension**
+  (`pyculiar._cext.anomaly_module`), implementing median, MAD, Student's-t
+  inverse CDF, additive classical seasonal decomposition, and the generalized
+  ESD test. The public `detect_ts` API is unchanged and produces the same
+  results; a golden-test suite locks in the previous implementation's exact
+  numeric output.
+- **The license is MIT** (was GPL-3.0).
+- **Import name is `pyculiar`** (was `pyculiarity`).
+- Minimum Python is 3.10; supported through 3.13.
+- Minimum pandas is 2.0 (tested against 2.x and 3.x).
+- Packaging moved from `setup.py` + `requirements.txt` to `pyproject.toml`.
+
+### Added
+
+- Prebuilt wheels on PyPI for Linux (x86_64, aarch64), macOS (x86_64, arm64),
+  and Windows across Python 3.10–3.13, so most installs no longer compile
+  anything. An sdist is published for platforms without a wheel.
+- Type stubs for the C extension (`pyculiar/_cext/anomaly_module.pyi`).
+- Golden tests covering the statistical primitives, seasonal decomposition,
+  `detect_anoms`, and end-to-end `detect_ts`, plus input-validation tests.
+- CI running lint and the test suite on Python 3.10–3.13 across Linux and macOS,
+  with CodeQL (Python and C) and `pip-audit` scanning.
+
+### Fixed
+
+- **The library works on modern pandas again.** Calls to APIs that pandas has
+  since removed — `Series.iget`, `Int64Index`, `convert_objects`, and
+  `DataFrame.append` — were replaced with supported equivalents. On pandas 2.x
+  these previously raised `AttributeError`, so `detect_ts` was effectively
+  unusable there.
+- Timestamp conversion and integer-division bugs in the test suite, plus uses of
+  the removed `DataFrame.set_value`, which had masked incorrect behaviour under
+  Python 3.
+
+[0.2.0]: https://github.com/wdm0006/pyculiar/releases/tag/v0.2.0


### PR DESCRIPTION
Prepares the **v0.2.0** release. This is the first release since `0.0.5` and the first to ship the C-based numerical core.

The only change in this PR is a new `CHANGELOG.md`. **No version bump was needed** — `pyproject.toml` and `pyculiar/__init__.py` both already read `0.2.0` (set in `bc4aed7`), they are in sync, and `v0.2.0` has never been tagged or published. PyPI currently serves `pyculiar` 0.0.5.

## Why now, per the release policy

The policy calls for a release on "any user-visible change" and specifically names the C rewrite and the scipy/statsmodels drop as minor-bump material. Everything since `0.0.5` qualifies — this is not a doc/CI-only accumulation:

- the entire numerical core was reimplemented in C (`bc4aed7`)
- `scipy`, `statsmodels`, `patsy`, `pytz`, and `future` were dropped as dependencies
- the import name changed `pyculiarity` → `pyculiar` (`fdae85d`)
- the license changed GPL-3.0 → MIT
- pandas 2.x compatibility was restored (`8a264c4`)

Version stays at `0.2.0` rather than jumping to `1.0.0`: the policy says not to leave pre-1.0 without a deliberate stability decision from you.

---

# Release notes — v0.2.0

First release since `0.0.5`. The library has been modernized for current Python and pandas, and its entire numerical core has been rewritten from scratch as a C extension — `scipy` and `statsmodels` are no longer dependencies.

The `detect_ts` signature, parameters, and results are unchanged, and its outputs are pinned to the previous implementation by golden tests. **The import name and the license both changed**, so read the migration notes before upgrading.

## Migrating from 0.0.5

**Import from `pyculiar`, not `pyculiarity`:**

```python
# before
from pyculiarity import detect_ts

# after
from pyculiar import detect_ts
```

The PyPI distribution name is unchanged (`pip install pyculiar`); only the module you import from moved, so that it matches the package name.

**The license changed from GPL-3.0 to MIT.** If your usage depended on the copyleft terms, review the new LICENSE.

**Python 3.10+ and pandas 2.0+ are now required.** Stay on `0.0.5` if you need Python 2 or pandas 1.x.

## Removed

- **`scipy`, `statsmodels`, `patsy`, `pytz`, and `future` are no longer dependencies.** Runtime requirements are now just `numpy` and `pandas>=2.0`.
- The `pyculiarity.stl` module (`stl()`, a statsmodels-backed LOESS decomposition) is gone. Seasonal decomposition now happens inside the C extension; call `pyculiar._cext.anomaly_module.seasonal_decompose(values, period)` if you were using it directly.
- Python 2 compatibility shims (`future`, `past.builtins`).

## Changed

- **The computational core is now a C extension** (`pyculiar._cext.anomaly_module`), implementing median, MAD, Student's-t inverse CDF, additive classical seasonal decomposition, and the generalized ESD test. The public `detect_ts` API is unchanged and produces the same results; a golden-test suite locks in the previous implementation's exact numeric output.
- **The license is MIT** (was GPL-3.0).
- **Import name is `pyculiar`** (was `pyculiarity`).
- Minimum Python is 3.10; supported through 3.13.
- Minimum pandas is 2.0 (tested against 2.x and 3.x).
- Packaging moved from `setup.py` + `requirements.txt` to `pyproject.toml`.

## Added

- Prebuilt wheels on PyPI for Linux (x86_64, aarch64), macOS (x86_64, arm64), and Windows across Python 3.10–3.13, so most installs no longer compile anything. An sdist is published for platforms without a wheel.
- Type stubs for the C extension (`pyculiar/_cext/anomaly_module.pyi`).
- Golden tests covering the statistical primitives, seasonal decomposition, `detect_anoms`, and end-to-end `detect_ts`, plus input-validation tests.
- CI running lint and the test suite on Python 3.10–3.13 across Linux and macOS, with CodeQL (Python and C) and `pip-audit` scanning.

## Fixed

- **The library works on modern pandas again.** Calls to APIs that pandas has since removed — `Series.iget`, `Int64Index`, `convert_objects`, and `DataFrame.append` — were replaced with supported equivalents. On pandas 2.x these previously raised `AttributeError`, so `detect_ts` was effectively unusable there.
- Timestamp conversion and integer-division bugs in the test suite, plus uses of the removed `DataFrame.set_value`, which had masked incorrect behaviour under Python 3.

---

## Verification

- `pytest tests/` on Python 3.12: **141 passed**.
- `uv build --sdist` succeeds; the tarball contains `anomaly_module.c` and the `.pyi` stub.
- The sdist was installed into a clean venv and imported **from outside the source tree** — the C extension compiles at install time and works (`t_ppf(0.975, 10)` = `2.2281388519860`, matching scipy to ~1e-11). This is the path platforms without a wheel take, and a failed compile would block the whole publish.
- The `Test` matrix (8 jobs, Python 3.10–3.13 × Linux/macOS) is **green on `master`**.

## ⚠️ Known issue — the `Lint & Format` CI job is red on `master`

This predates this PR and is **not** introduced by it. On `master`, `ruff format . --check` reports 12 unformatted files and `ruff check .` reports 34 errors:

- 12 unformatted files: `README.md`, `examples/*.py`, `tests/*.py` — all single-quote → double-quote churn. **None are in the shipped `pyculiar/` package**, which is format-clean.
- The `ruff check` errors include some inside `pyculiar/` (import sorting, `%`-format, `TRY004`) surfaced by the *default* rule set — CI does `pip install ruff` unpinned and `pyproject.toml` sets no `[tool.ruff] select`, so the rule set silently widens on every ruff release.

I deliberately did **not** fix this here — a 12-file reformat plus lint sweep does not belong in a release PR, and some of the suggested fixes (`TRY004`) would change which exception type `detect_ts` raises, i.e. a behaviour change. It is worth its own PR, and pinning `select` would stop the gate drifting.

**This does not block the release.** `publish.yml` triggers on the tag and has no dependency on `ci.yml`, so the publish will run regardless. The functional gate — the test matrix — is green.

## Downstream

None. No other repository depends on `pyculiar` (or its former import name `pyculiarity`), so there are no dependency bumps to fan out after the tag lands.

## Post-merge steps — to actually publish

```
git checkout master && git pull
git tag -a v0.2.0 -m "v0.2.0" && git push origin v0.2.0
```

Pushing the `v0.2.0` tag triggers the **"Publish to PyPI"** workflow (`.github/workflows/publish.yml`), which builds wheels with `cibuildwheel` for Linux (x86_64 + aarch64 via QEMU), macOS (x86_64 + arm64), and Windows — skipping PyPy and musllinux — builds an sdist with `python -m build --sdist`, and publishes everything to PyPI via `pypa/gh-action-pypi-publish` using trusted publishing (OIDC, no stored token).

Optionally, create a GitHub Release for the `v0.2.0` tag and paste the release-notes section above as its body.